### PR TITLE
Add support for the arm64 architecture

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: bash
 dist: xenial
+arch:
+  - amd64
+  - arm64 
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: bash
 dist: xenial
-arch:
-  - amd64
-  - arm64 
+arch: amd64
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ addons:
   snaps:
     - name: snapcraft
       channel: stable
-      classic: true
+      confinement: classic
     - name: http
     - name: transfer
     - name: lxd

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: sublime-merge
-version: "2020"
+version: "2039"
 summary: Meet a new Git Client, from the makers of Sublime Text
 base: core18
 description: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -6,7 +6,7 @@ description: |
   Meet a new Git Client, from the makers of Sublime Text.
 
 architectures:
-  - build-on: amd64
+  - build-on: [amd64, arm64]
 
 grade: stable
 confinement: classic
@@ -24,7 +24,15 @@ parts:
       VERSION=$SNAPCRAFT_PROJECT_VERSION
       snapcraftctl set-version $(echo $VERSION)
       rm -f release.txt 2>/dev/null
-      BUILD="x64"
+      ARCHITECTURE=$(dpkg --print-architecture)
+      if [ "${ARCHITECTURE}" = "amd64" ]; then
+        BUILD="x64"
+      elif [ "${ARCHITECTURE}" = "arm64" ]; then
+        BUILD="arm64"
+      else
+        echo "ERROR! Sublime Merge tarballs are only available for amd64 and arm64. Failing the build here."
+        exit 1
+      fi
       TARBALL="sublime_merge_build_${VERSION}_${BUILD}.tar.xz"
       TARBALL_URL="https://download.sublimetext.com/${TARBALL}"
       echo "Downloading ${TARBALL_URL}..."

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -6,7 +6,8 @@ description: |
   Meet a new Git Client, from the makers of Sublime Text.
 
 architectures:
-  - build-on: [amd64, arm64]
+  - build-on: amd64
+  - build-on: arm64
 
 grade: stable
 confinement: classic


### PR DESCRIPTION
Fixes #4 

Sublime Merge is now releasing packages for 64-bit ARM on Linux and this PR adds support for those.

This feature bumps the version of Sublime Merge to the most recent, since version 2020 does not have arm64 tarballs.