### PR TITLE
simplify the source of the snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -20,43 +20,14 @@ apps:
 
 parts:
   sublime-merge:
-    plugin: nil
+    source: https://download.sublimetext.com/sublime-merge_build-${SNAPCRAFT_PROJECT_VERSION}_${SNAPCRAFT_TARGET_ARCH}.deb
+    plugin: dump
     override-build: |
       snapcraftctl build
-      VERSION=$SNAPCRAFT_PROJECT_VERSION
-      snapcraftctl set-version $(echo $VERSION)
-      rm -f release.txt 2>/dev/null
-      ARCHITECTURE=$(dpkg --print-architecture)
-      if [ "${ARCHITECTURE}" = "amd64" ]; then
-        BUILD="x64"
-      elif [ "${ARCHITECTURE}" = "arm64" ]; then
-        BUILD="arm64"
-      else
-        echo "ERROR! Sublime Merge tarballs are only available for amd64 and arm64. Failing the build here."
-        exit 1
-      fi
-      TARBALL="sublime_merge_build_${VERSION}_${BUILD}.tar.xz"
-      TARBALL_URL="https://download.sublimetext.com/${TARBALL}"
-      echo "Downloading ${TARBALL_URL}..."
-      wget --quiet "${TARBALL_URL}" -O "${SNAPCRAFT_PART_INSTALL}/${TARBALL}"
-
-      echo "Unpacking ${TARBALL}..."
-      mkdir -p "${SNAPCRAFT_PART_INSTALL}/opt"
-      tar xf "${SNAPCRAFT_PART_INSTALL}/${TARBALL}" -C "${SNAPCRAFT_PART_INSTALL}/opt"
-      rm "${SNAPCRAFT_PART_INSTALL}/${TARBALL}"
-
-      # Correct the extraction path so it matches assets held within.
-      #mv "${SNAPCRAFT_PART_INSTALL}/opt/sublime_merge" "${SNAPCRAFT_PART_INSTALL}/opt/sublime_merge"
-
       # Correct icon path
-      sed -i 's|Icon=sublime-merge|Icon=/opt/sublime_merge/Icon/256x256/sublime-merge.png|' $SNAPCRAFT_PART_INSTALL/opt/sublime_merge/sublime_merge.desktop
+      sed -i 's|Icon=sublime-merge|Icon=/opt/sublime_merge/Icon/256x256/sublime-merge.png|' ${SNAPCRAFT_PART_INSTALL}/opt/sublime_merge/sublime_merge.desktop
       # Desktop Action are not Unity specific.
-      sed -i 's|OnlyShowIn|#OnlyShowIn|g' $SNAPCRAFT_PART_INSTALL/opt/sublime_merge/sublime_merge.desktop
-    build-packages:
-      - dpkg
-      - sed
-      - tar
-      - wget
+      sed -i 's|OnlyShowIn|#OnlyShowIn|g' ${SNAPCRAFT_PART_INSTALL}/opt/sublime_merge/sublime_merge.desktop
     stage-packages:
       - libbsd0
       - libffi6

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,7 +15,7 @@ confinement: classic
 apps:
   sublime-merge:
     command: opt/sublime_merge/sublime_merge
-    desktop: opt/sublime_merge/sublime_merge.desktop
+    desktop: usr/share/applications/sublime_merge.desktop
     aliases: [smerge]
 
 parts:
@@ -25,9 +25,9 @@ parts:
     override-build: |
       snapcraftctl build
       # Correct icon path
-      sed -i 's|Icon=sublime-merge|Icon=/opt/sublime_merge/Icon/256x256/sublime-merge.png|' ${SNAPCRAFT_PART_INSTALL}/opt/sublime_merge/sublime_merge.desktop
+      sed -i 's|Icon=sublime-merge|Icon=/opt/sublime_merge/Icon/256x256/sublime-merge.png|' ${SNAPCRAFT_PART_INSTALL}/usr/share/applications/sublime_merge.desktop
       # Desktop Action are not Unity specific.
-      sed -i 's|OnlyShowIn|#OnlyShowIn|g' ${SNAPCRAFT_PART_INSTALL}/opt/sublime_merge/sublime_merge.desktop
+      sed -i 's|OnlyShowIn|#OnlyShowIn|g' ${SNAPCRAFT_PART_INSTALL}/usr/share/applications/sublime_merge.desktop
     stage-packages:
       - libbsd0
       - libffi6


### PR DESCRIPTION
Allows the workflow to actually update the snap.

Working in 

## `23.10`

![image](https://github.com/snapcrafters/sublime-merge/assets/72045785/a1199ab1-0560-41e1-9c83-6e476e832654)

## `22.04`

![image](https://github.com/snapcrafters/sublime-merge/assets/72045785/7598be98-bb0b-4a70-bbff-4d16af05f21e)

## `20.04`

![image](https://github.com/snapcrafters/sublime-merge/assets/72045785/cc1e954e-9a92-449f-9a50-ca58daf241d8)

## `18.04`

![image](https://github.com/snapcrafters/sublime-merge/assets/72045785/94f0ba9f-a92c-4157-8819-aa59afa3b9f5)
