### PR TITLE
ci: use snapcraft 7.x/stable throughout

### DIFF
--- a/.github/workflows/promote-to-stable.yml
+++ b/.github/workflows/promote-to-stable.yml
@@ -23,3 +23,4 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           store-token: ${{ secrets.SNAP_STORE_STABLE }}
+          snapcraft-channel: 7.x/stable

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,7 +2,7 @@ name: Pull Request
 
 on:
   pull_request:
-    branches: [ "**" ]
+    branches: ["**"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -15,3 +15,5 @@ jobs:
     steps:
       - name: 🧪 Build snap on amd64
         uses: snapcrafters/ci/test-snap-build@main
+        with:
+          snapcraft-channel: 7.x/stable

--- a/.github/workflows/release-to-candidate.yml
+++ b/.github/workflows/release-to-candidate.yml
@@ -1,9 +1,9 @@
 name: Release
 
 on:
-  # Run the workflow each time new commits are pushed to the candidate branch. 
+  # Run the workflow each time new commits are pushed to the candidate branch.
   push:
-    branches: [ "candidate" ]
+    branches: ["candidate"]
   workflow_dispatch:
 
 concurrency:
@@ -14,7 +14,7 @@ permissions:
   contents: read
   issues: write
 
-jobs: 
+jobs:
   get-architectures:
     name: 🖥 Get snap architectures
     runs-on: ubuntu-latest
@@ -42,7 +42,8 @@ jobs:
           launchpad-token: ${{ secrets.LP_BUILD_SECRET }}
           repo-token: ${{ secrets.SNAPCRAFTERS_BOT_COMMIT }}
           store-token: ${{ secrets.SNAP_STORE_CANDIDATE }}
-  
+          snapcraft-channel: 7.x/stable
+
   call-for-testing:
     name: 📣 Create call for testing
     needs: [release, get-architectures]
@@ -57,6 +58,7 @@ jobs:
         with:
           architectures: ${{ needs.get-architectures.outputs.architectures }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          snapcraft-channel: 7.x/stable
 
   screenshots:
     name: 📸 Gather screenshots


### PR DESCRIPTION
This snap is currently based on core18, which isn't supported by Snapcraft 8. This change ensures that the CI system only uses snapcraft 7.x/stable when building/testing/publishing.

Merge after snapcrafters/ci#27 has merged.