### PR TITLE
ci: prepare for promotion/PRs on seperate branches

### DIFF
--- a/.github/workflows/promote-to-stable.yml
+++ b/.github/workflows/promote-to-stable.yml
@@ -9,18 +9,37 @@ permissions:
   issues: write
 
 jobs:
-  promote:
-    name: ⬆️ Promote to stable
+  promote-latest:
+    name: ⬆️ Promote to latest/stable
     environment: "Candidate Branch"
     runs-on: ubuntu-latest
     if: |
       ( !github.event.issue.pull_request )
       && contains(github.event.comment.body, '/promote ')
+      && contains(github.event.comment.body, 'latest/stable')
+      && contains(github.event.issue.body, 'latest/stable')
       && contains(github.event.*.labels.*.name, 'testing')
     steps:
-      - name: ⬆️ Promote to stable
+      - name: ⬆️ Promote to latest/stable
         uses: snapcrafters/ci/promote-to-stable@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           store-token: ${{ secrets.SNAP_STORE_STABLE }}
-          snapcraft-channel: 7.x/stable
+
+  promote-dev:
+    name: ⬆️ Promote to dev/stable
+    environment: "Dev Branch"
+    runs-on: ubuntu-latest
+    if: |
+      ( !github.event.issue.pull_request )
+      && contains(github.event.comment.body, '/promote ')
+      && contains(github.event.comment.body, 'dev/stable')
+      && contains(github.event.issue.body, 'dev/stable')
+      && contains(github.event.*.labels.*.name, 'testing')
+    steps:
+      - name: ⬆️ Promote to dev/stable
+        uses: snapcrafters/ci/promote-to-stable@main
+        with:
+          channel: dev/stable
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          store-token: ${{ secrets.SNAP_STORE_STABLE }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,7 +2,7 @@ name: Pull Request
 
 on:
   pull_request:
-    branches: ["**"]
+    branches: ["candidate"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -3,7 +3,7 @@ name: Update
 on:
   # Runs at 10:00 UTC every day
   schedule:
-    - cron:  '0 10 * * *'
+    - cron: "0 10 * * *"
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -24,10 +24,17 @@ jobs:
           update-script: |
             stable_version="$(curl -sL https://www.sublimemerge.com/download | grep -Po '<p class="latest"><i>Version:</i> Build \K[0-9]+')"
             sed -i 's/^\(version: \).*$/\1'"\"$stable_version\""'/' snap/snapcraft.yaml
-            # Support for dev will be added later
-            # dev_version="$(curl -sL https://www.sublimemerge.com/dev | grep -Po '<p class="latest"><i>Version:</i> Build \K[0-9]+')"
-            # if [[ "$stable_version" > "$dev_version" ]]; then
-            #     yq -i ".version = \"$stable_version\"" snap/snapcraft.yaml
-            # else
-            #     yq -i ".version = \"$dev_version-dev\"" snap/snapcraft.yaml
-            # fi
+
+  sync-dev:
+    name: Sync dev version with upstream
+    environment: "Dev Branch"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sync version with upstream
+        uses: snapcrafters/ci/sync-version@main
+        with:
+          branch: dev
+          token: ${{ secrets.SNAPCRAFTERS_BOT_COMMIT }}
+          update-script: |
+            dev_version="$(curl -sL https://www.sublimemerge.com/dev | grep -Po '<p class="latest"><i>Version:</i> Build \K[0-9]+')"
+            sed -i 's/^\(version: \).*$/\1'"\"$dev_version\""'/' snap/snapcraft.yaml


### PR DESCRIPTION
Part 2 of #32 

Workflows can only be triggered by issues on the default branch, so this adds similar handling as in `gimp` so that the automation can discern the difference between promoting to latest/candidate and `dev/candidate`.